### PR TITLE
v4.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jabrahearing/react-native-notifications",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Republished as `v4.1.11`

I published `v4.1.10` without building first, `dist/` not created 😢 