### PR TITLE
[APP-3036] https://github.com/wix/react-native-notifications/issues/975

### DIFF
--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -99,7 +99,7 @@ android {
     testOptions {
         unitTests.all { t ->
             reports {
-                html.enabled true
+                html.required.set true
             }
             testLogging {
                 events "PASSED", "SKIPPED", "FAILED", "standardOut", "standardError"


### PR DESCRIPTION
This PR addresses this build error:

> Could not create task ':react-native-notifications:testReactNative60DebugUnitTest'.
No signature of method: org.gradle.api.reporting.internal.TaskGeneratedSingleDirectoryReport.enabled() is applicable for argument types: (Boolean) values: [true]

I've only noticed it happens when building via the command line

From: https://github.com/wix/react-native-notifications/issues/975

